### PR TITLE
Load inline css into the iframe

### DIFF
--- a/src/drawio-client/init/index.ts
+++ b/src/drawio-client/init/index.ts
@@ -1,7 +1,9 @@
 import { Frame } from "./Frame";
 import Responses from "./Responses";
-import { loadStylesheet, RequestManager } from "./RequestManager";
+import { RequestManager } from "./RequestManager";
 import { ConfigurationManager } from "./ConfigurationManager";
+import drawioCss from "inline!./src/drawio-client/drawio.css";
+import darkmodeCss from "inline!./src/assets/dark.css";
 
 /**
  * This is the entry point that is loaded into the iframe.
@@ -14,10 +16,12 @@ import { ConfigurationManager } from "./ConfigurationManager";
 function init(win: Window) {
   // Intercept requests for resources made by drawio so it can run offline
   RequestManager.interceptRequests(Responses);
-  loadStylesheet("local://drawio.css");
-
   // Prepare the window to inject the drawio application code into it.
-  Frame.main(win, new ConfigurationManager(win));
+  const frame = Frame.main(win, new ConfigurationManager(win));
+  // load the css files in directly into to the frame
+  // to get around obsidian's new content security policy
+  frame.addCss(drawioCss);
+  frame.addCss(darkmodeCss);
 }
 
 init(window);


### PR DESCRIPTION
The latest update of Obsidian broke this plugin since it loads CSS in a way that goes against the new content security policy in Obsidian 1.56+

Following the thread in #89 I am not about to download some file from a random google drive so I wanted to get the temporary fix into a branch for others to consume and possibly to upstream.

This seems to work for dark mode partially (the graph itself and shapes don't seem to be getting dark mode applied, probably a different set of assets getting blocked?) but when I try to switch back to light mode it doesn't work. Ideally the `RequestManager` probably needs to be reworked so that it works with the new CSP. I do not have the time right now to dig into that.