### PR TITLE
Quick fix for compatibility with newer Obsidian version.

### DIFF
--- a/src/LoadProgress.ts
+++ b/src/LoadProgress.ts
@@ -5,6 +5,22 @@ export function createLoadProgress(
   container: HTMLElement
 ): LoadProgress {
   const obsidianAppLoadProgress = app.loadProgress;
+  if(!obsidianAppLoadProgress) {
+    return {
+      setMessage: function (message: string){
+        console.log('Set message', message);
+        return this
+      },
+      show: function (){
+        console.log('Set loading');
+        return this
+      },
+      hide: function (){
+        console.log('Set hiding');
+        return this
+      }
+    }
+  }
   const ObsidianLoadProgress = Object.getPrototypeOf(
     obsidianAppLoadProgress
   ).constructor;


### PR DESCRIPTION
This is an interim fix for the issue in the new Obsidian versions. app.loadProgress usage needs to be reworked in further commits.