### PR TITLE
Allow user setting for new diagram folder

### DIFF
--- a/src/DiagramPlugin.ts
+++ b/src/DiagramPlugin.ts
@@ -179,7 +179,7 @@ export default class DiagramPlugin extends Plugin {
         .setTitle("Insert new diagram")
         .setIcon("create-new-diagram")
         .onClick(async () => {
-          const file = await this.createNewDiagramFile(view.file.parent);
+          const file = await this.createNewDiagramFile();
           editor.replaceSelection(`![[${file.path}]]`);
           const leaf = this.app.workspace.getLeaf(true);
           await leaf.setViewState({
@@ -267,9 +267,19 @@ export default class DiagramPlugin extends Plugin {
   }
 
   private async createNewDiagramFile(folder?: TFolder) {
-    const targetFolder = folder
-      ? folder
-      : this.app.fileManager.getNewFileParent("");
+    let targetFolder: TFolder;
+    if (folder) {
+      targetFolder = folder;
+    } else {
+      const folderPath = this.settings.diagramFolder?.trim();
+      const userDefinedFolder = folderPath
+        ? this.app.vault.getAbstractFileByPath(folderPath)
+        : null;
+      targetFolder =
+        userDefinedFolder instanceof TFolder
+          ? userDefinedFolder
+          : this.app.fileManager.getNewFileParent("");
+    }
     const newFilePath = await this.getNewDiagramFilePath(
       targetFolder,
       "Untitled Diagram",

--- a/src/DiagramPluginSettings.ts
+++ b/src/DiagramPluginSettings.ts
@@ -16,6 +16,7 @@ export interface DiagramPluginSettings {
     sketch: optionalBoolean;
   };
   cssSnippets: string[];
+  diagramFolder?: string;
 }
 
 export const DEFAULT_SETTINGS: DiagramPluginSettings = {
@@ -28,4 +29,5 @@ export const DEFAULT_SETTINGS: DiagramPluginSettings = {
     sketch: true,
   },
   cssSnippets: [],
+  diagramFolder: "",
 };

--- a/src/DiagramSettingsTab.ts
+++ b/src/DiagramSettingsTab.ts
@@ -99,5 +99,17 @@ export default class DiagramSettingsTab extends PluginSettingTab {
             this.plugin.settings.cssSnippets = value.split("\n")
             await this.plugin.saveSettings();
         }));
+
+    new Setting(containerEl)
+      .setName("Diagram Folder")
+      .setDesc("Default location for new drawings. If empty, drawings will be created in Vault root. Note: If right-clicking a folder, the drawing will be created in that folder instead.")
+      .addText(text => text
+        .setPlaceholder("Example: drawings")
+        .setValue(this.plugin.settings.diagramFolder || "")
+        .onChange(async (value) => {
+          this.plugin.settings.diagramFolder = value.trim();
+          await this.plugin.saveSettings();
+        })
+      );
   }
 }


### PR DESCRIPTION
Allow user setting for new diagram folder when insert diagram via editor and fileExplorer button. 
New diagram via right-click on folder are not affected.

This should solve the following issues raised in #9 , #67 and #82.