### PR TITLE
fix: guard setStatusText against null statusContainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ data.json
 # IDE exclusions
 .idea
 *.iml
+
+# git worktrees
+.worktrees/

--- a/src/drawio-client/app/Plugin.ts
+++ b/src/drawio-client/app/Plugin.ts
@@ -126,6 +126,12 @@ export default class Plugin {
     // Remove the status elements because this plugin manages saving the diagram
     app.statusContainer.remove();
     app.statusContainer = null;
+
+    // Guard setStatusText against null statusContainer after removal
+    patch(EditorUi.prototype, "setStatusText", (fn) => function (this: EditorUi, ...args: any[]) {
+      if (this.statusContainer == null) return;
+      return fn.apply(this, args);
+    });
     if (
       app.menubarContainer.parentElement.firstChild === app.menubarContainer &&
       app.menubarContainer.parentElement.childElementCount === 1


### PR DESCRIPTION
## Summary

- `Plugin.ts` intentionally sets `statusContainer` to `null` after removing the draw.io status bar
- However, `EditorUi.setStatusText` still fires on keyboard events, crashing with: `TypeError: Cannot set properties of null (setting 'innerHTML')`
- Patch `setStatusText` to no-op when `statusContainer` is null

## Test plan

- [ ] Open a diagram in the editor
- [ ] Trigger keyboard events (e.g. undo, redo, typing) that would normally call `setStatusText`
- [ ] Verify no `TypeError: Cannot set properties of null` error appears in the console
- [ ] Confirm the status bar behavior is otherwise unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)