### PR TITLE
feat: click title to rename diagram, update header on vault rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ data.json
 # IDE exclusions
 .idea
 *.iml
+
+# git worktrees
+.worktrees/

--- a/src/DiagramEditView.ts
+++ b/src/DiagramEditView.ts
@@ -1,4 +1,4 @@
-import { LoadProgress, TFile, ViewState, WorkspaceLeaf } from "obsidian";
+import { LoadProgress, Modal, TFile, ViewState, WorkspaceLeaf } from "obsidian";
 import DiagramPlugin from "./DiagramPlugin";
 import DiagramViewBase from "./DiagramViewBase";
 import { DIAGRAM_EDIT_VIEW_TYPE, DIAGRAM_VIEW_TYPE } from "./constants";
@@ -93,6 +93,21 @@ export class DiagramEditView extends DiagramViewBase {
     } as ViewState);
   }
 
+  async onRename(file: TFile) {
+    await super.onRename(file);
+  }
+
+  private openRenameModal() {
+    if (!this.file) return;
+    const basename = this.file.basename;
+    new RenameModal(this.app, basename, async (newName) => {
+      if (newName && newName !== basename) {
+        const newPath = this.file.path.replace(/[^/]+$/, newName + "." + this.file.extension);
+        await this.app.fileManager.renameFile(this.file, newPath);
+      }
+    }).open();
+  }
+
   async onLoadFile(file: TFile) {
     const data = await this.app.vault.read(file);
     (async () => {
@@ -140,6 +155,20 @@ export class DiagramEditView extends DiagramViewBase {
     this.drawioClient.addEventListener("focusin", () =>
       this.app.workspace.setActiveLeaf(this.leaf)
     );
+
+    const headerTitle = this.containerEl.querySelector(".view-header-title") as HTMLElement;
+    if (headerTitle) {
+      this.registerDomEvent(headerTitle, "click", () => this.openRenameModal());
+      headerTitle.style.cursor = "pointer";
+    }
+
+    this.registerEvent(this.app.vault.on("rename", (file: TFile, oldPath: string) => {
+      if (this.file && this.file.path === file.path) {
+        const titleEl = this.containerEl.querySelector(".view-header-title") as HTMLElement;
+        if (titleEl) titleEl.textContent = file.name;
+        (this.leaf as any).updateHeader?.();
+      }
+    }));
   }
 
   async onClose() {
@@ -157,5 +186,48 @@ export class DiagramEditView extends DiagramViewBase {
     this.contentEl.style.margin = "0";
     this.contentEl.style.padding = "0";
     this.contentEl.style.position = "relative";
+  }
+}
+
+class RenameModal extends Modal {
+  private cur: string;
+  private cb: (newName: string | null) => void;
+
+  constructor(app: any, cur: string, cb: (newName: string | null) => void) {
+    super(app);
+    this.cur = cur;
+    this.cb = cb;
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.createEl("h3", { text: "Rename diagram" });
+    const inp = contentEl.createEl("input", { type: "text" } as any);
+    inp.value = this.cur;
+    inp.style.width = "100%";
+    inp.select();
+    inp.addEventListener("keydown", (ev: KeyboardEvent) => {
+      if (ev.key === "Enter") {
+        this.cb(inp.value.trim() || null);
+        this.close();
+      }
+      if (ev.key === "Escape") {
+        this.cb(null);
+        this.close();
+      }
+    });
+    const row = contentEl.createDiv({ cls: "modal-button-container" });
+    row.createEl("button", { text: "Rename", cls: "mod-cta" }).addEventListener("click", () => {
+      this.cb(inp.value.trim() || null);
+      this.close();
+    });
+    row.createEl("button", { text: "Cancel" }).addEventListener("click", () => {
+      this.cb(null);
+      this.close();
+    });
+  }
+
+  onClose() {
+    this.contentEl.empty();
   }
 }

--- a/src/drawio-client/app/Plugin.ts
+++ b/src/drawio-client/app/Plugin.ts
@@ -126,6 +126,12 @@ export default class Plugin {
     // Remove the status elements because this plugin manages saving the diagram
     app.statusContainer.remove();
     app.statusContainer = null;
+
+    // Guard setStatusText against null statusContainer after removal
+    patch(EditorUi.prototype, "setStatusText", (fn) => function (this: EditorUi, ...args: any[]) {
+      if (this.statusContainer == null) return;
+      return fn.apply(this, args);
+    });
     if (
       app.menubarContainer.parentElement.firstChild === app.menubarContainer &&
       app.menubarContainer.parentElement.childElementCount === 1


### PR DESCRIPTION
## Summary

- Clicking `.view-header-title` opens a rename modal with confirm (Enter) / cancel (Escape / button) support
- After `renameFile` resolves, listens to the vault `rename` event to update the header title immediately (the `onRename` hook is not reliably called in this plugin's view context)

## Test plan

- [ ] Open a diagram and click the title in the header — a rename modal should appear
- [ ] Enter a new name and press Enter (or click confirm) — the file should be renamed and the header title updated
- [ ] Press Escape (or click cancel) — the modal should close without renaming
- [ ] Rename the file from the Obsidian file explorer — the header title should update automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)