### PR TITLE
Mobile (iOS/iPadOS) support (#33)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+# Build environment for the drawio-obsidian plugin.
+# Pinned to Node 18 to match the Rollup 2.x / TypeScript 4.4 toolchain the
+# project was written against. Everything needed to build lives in this image,
+# so nothing has to be installed on the host.
+FROM node:18-bookworm
+
+# git: required to fetch / update the jgraph/drawio submodule.
+# ca-certificates: HTTPS for npm + git.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "drawio-obsidian (mobile build)",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "remoteUser": "node",
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "editor.formatOnSave": false
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# drawio-obsidian — Mobile (iOS/iPadOS) support — WORK IN PROGRESS
+
+Fork of `zapthedingbat/drawio-obsidian` adding iPhone/iPad support.
+Branch: `mobile-support`. Fork: `llabusch93/drawio-obsidian`.
+Draft PR: `zapthedingbat/drawio-obsidian#120` (addresses upstream issue #33).
+
+## STATUS (2026-06-05): NOT WORKING YET — editor blank on iPad
+
+Desktop is unaffected. On iPad the editor view opens but the drawio canvas stays
+blank. The transport fix landed, but drawio's `app.min.js` still fails to start
+on iOS and the real error is being masked. Root cause not yet identified. The
+vault copy has been reverted to the original 1.5.4 desktop-only build.
+
+## Build & deploy (everything in Docker, nothing on the host)
+
+```
+devcontainer up --workspace-folder .                      # once
+devcontainer exec --workspace-folder . npm run build      # -> dist/main.js (~8 MB)
+OBSIDIAN_VAULT=/Users/llabusch/Documents/SecondBrain ./scripts/deploy-to-vault.sh
+```
+
+- TS is transpiled with **sucrase**, NOT `@rollup/plugin-typescript` (the latter
+  breaks under the pinned TS 4.4 on newer `@codemirror` type-only-export syntax).
+- The `jgraph/drawio` submodule (pinned `4776522`) must be checked out or main.js
+  cannot inline the 8 MB app. Restore it with a shallow SHA fetch over HTTPS:
+  `git -C drawio init && git -C drawio remote add origin https://github.com/jgraph/drawio.git && git -C drawio fetch --depth 1 origin 4776522cd7b6a958c87babebf4ac45b6388828d2 && git -C drawio checkout FETCH_HEAD`
+- On iPad, Obsidian only re-reads main.js after a FULL app quit + reopen (toggling
+  the plugin is unreliable for an 8 MB file). Obsidian mobile's webview is NOT
+  Safari-inspectable (App Store build) — debug via the on-screen diagnostic
+  Notice, not Web Inspector.
+
+## What is confirmed working / fixed
+
+- **Transport: `data:` URL → `iframe.srcdoc`** (`DrawioClient.createFrameElement`).
+  The original `data:text/html,` frame has a null origin in iOS WKWebView, which
+  blocks `<script>` injection and the parent<->child postMessage handshake.
+  srcdoc is same-origin. CONFIRMED on device: `gotIframeMsg=true, bootRan=true`.
+- **`Frame.ts` cookie + localStorage stubs**: the original
+  `Object.defineProperty(document,"cookie",…)` and `…"localStorage"…` were written
+  for the `data:` URL's opaque origin. On same-origin srcdoc those native
+  accessors are non-configurable, so the defineProperty THREW and aborted init
+  before `mxLoadResources=false`/`mxscript` were set. Now wrapped in try/catch.
+  CONFIRMED fixed on device: `mxLoadResources=false` is now reached.
+
+## The open bug
+
+On iPad the diagnostic Notice reports (build `[b6]`):
+
+```
+gotIframeMsg=true, bootRan=true, scripts=4, mxLoadResources=false,
+mxClient=false, app=false, missing=none,
+errs=err:Script error.@?:0 ; err:Script error.@?:0
+```
+
+Reading: srcdoc + bootstrap + init all run; all 4 scripts inject; init completes;
+NO missing/cross-origin resources are requested; but drawio's `app.min.js` fails
+to define `mxClient` and throws **two errors that iOS masks as opaque
+"Script error." (no file/line)** via `window.onerror`.
+
+### Ruled out
+- Node/Electron deps (none exist).
+- The transport (srcdoc works — handshake completes).
+- cookie / localStorage defineProperty (fixed).
+- Missing / cross-origin resource loads (`missing=none`).
+- A synchronous top-level throw (`Frame.addScript` wraps `appendChild`; no
+  `addScript:` entry was ever captured).
+- A `setTimeout` / `requestAnimationFrame` callback throw (wrapped; no `async:`
+  entry captured).
+
+### Why the error is opaque
+iOS WKWebView reports errors from `about:srcdoc` scripts as cross-origin-sanitized
+"Script error." in `window.onerror` (message only, `error` object null, no
+file/line). Only a same-origin `try/catch` in the actual failing execution
+context can reveal it.
+
+### NEXT STEPS (start here next session)
+1. The `[b6]` build (currently committed) added a **`console.error` override** and
+   an **`addEventListener` callback wrap** in `Frame.ts` to catch the real error
+   (drawio usually `console.error`s its own failures; `App.main` may run on the
+   window `load` event). It was deployed but the resulting Notice `errs=` line was
+   **not yet read**. First action: rebuild/deploy `[b6]`, retest on iPad, read
+   `errs=` for a `cerr:` / new entry — that should finally name the failure.
+2. If still opaque, strongest hypothesis: **iOS WKWebView chokes on the ~8 MB
+   inline script** (`scriptElement.text = <8MB>` in `Frame.addScript`). Try
+   loading `app.min.js` via a **blob: URL `<script src>`** instead of inline text,
+   and add a `blob:` passthrough to `RequestManager.resolveResourceUrl` (it
+   currently rewrites unknown URLs to `https://app.diagrams.net/...`).
+3. Re-verify the `mxClient` probe (it is conceivable `App` is defined while
+   `mxClient` reads false — double-check the detection in `reportDiagnostics`).
+
+## Diagnostic scaffolding to REMOVE before merge (NOT for shipping)
+- `DrawioClient.ts`: `reportDiagnostics()`, the `gotIframeMsg` field, the
+  `__bootRan/__bootErr` block inside the srcdoc bootstrap, the `[b6]` Notice, and
+  the `Notice` import if it ends up unused.
+- `Frame.ts`: the whole async-capture block (`reportAsync`, `wrapAsync`, the
+  `setTimeout`/`requestAnimationFrame`/`addEventListener` wraps, the
+  `console.error` override) and the try/catch reporting inside `addScript`.
+  KEEP the cookie + localStorage try/catch — those are real fixes.
+- `RequestManager.ts`: the `__missingRes` tracking.
+
+## Keepers (the real change set)
+- `DrawioClient.ts`: srcdoc transport (+ viewport meta / `touch-action`).
+- `Frame.ts`: cookie + localStorage try/catch.
+- `DiagramViewBase.ts`: mobile PNG-to-vault export.
+- `DiagramPlugin.ts`: mobile ribbon icon + file-explorer optional chaining.
+- `FontManager.ts`: fetch try/catch (offline/mobile safe).
+- `manifest.json`: `isDesktopOnly:false`, `minAppVersion:1.0.0`, version `1.6.0`.
+- `rollup.config.js` + `package.json`: sucrase build.
+- `.devcontainer/`, `scripts/deploy-to-vault.sh`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "id": "drawio-obsidian",
   "name": "Diagrams",
-  "version": "1.5.4",
-  "minAppVersion": "0.9.12",
+  "version": "1.6.0",
+  "minAppVersion": "1.0.0",
   "description": "Draw.io diagrams for Obsidian. This plugin introduces diagrams that can be included within notes or as stand-alone files. Diagrams are created as SVG files (although .drawio extensions are also supported).",
   "author": "Sam Greenhalgh",
   "authorUrl": "https://www.radicalresearch.co.uk/",
-  "isDesktopOnly": true
+  "isDesktopOnly": false
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@rollup/plugin-typescript": "8.2.5",
+    "@rollup/plugin-sucrase": "5.1.0",
     "@types/chai": "4.3.1",
     "@types/mocha": "9.1.1",
     "@types/node": "14.17.15",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,6 @@
-import typescript from "@rollup/plugin-typescript";
+import { resolve as resolvePath } from "path";
+import { existsSync } from "fs";
+import sucrase from "@rollup/plugin-sucrase";
 import { terser } from "rollup-plugin-terser";
 import copy from "rollup-plugin-copy";
 import clear from "rollup-plugin-clear";
@@ -10,6 +12,44 @@ Draw.io Diagrams Obsidian Plugin
 2021 - Sam Greenhalgh - https://radicalresearch.co.uk/
 */
 `;
+
+// Transpile-only TypeScript via sucrase. No type-checking is performed, which
+// deliberately sidesteps the third-party .d.ts parsing problems (e.g.
+// @codemirror's `export { type X }` syntax) that broke @rollup/plugin-typescript
+// when resolved against an older TypeScript. We restrict it to real .ts/.tsx
+// source files so it never re-processes the JS strings synthesized by the
+// inline!/base64!/bundle! resolvers.
+const transpile = () =>
+  sucrase({
+    include: ["**/*.ts", "**/*.tsx"],
+    exclude: ["**/*.d.ts", "node_modules/**"],
+    transforms: ["typescript"],
+  });
+
+// Replicate the tsconfig `baseUrl: "."` resolution that @rollup/plugin-typescript
+// performed implicitly. Sucrase only resolves relative ("./", "../") imports, so
+// bare project-root imports such as `src/Messages` would otherwise be treated as
+// external. Map them back onto real source files under the repo root.
+const baseUrl = () => ({
+  name: "rollup-plugin-baseurl-resolve",
+  resolveId(importee) {
+    if (/^(src|typings)\//.test(importee)) {
+      const base = resolvePath(__dirname, importee);
+      const candidates = [
+        `${base}.ts`,
+        `${base}.tsx`,
+        `${base}/index.ts`,
+        `${base}/index.tsx`,
+        base,
+      ];
+      const match = candidates.find((candidate) => existsSync(candidate));
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  },
+});
 
 const chunkCache = new Map();
 
@@ -23,11 +63,10 @@ export default [
       banner,
     },
     plugins: [
+      baseUrl(),
       inline(),
-      typescript({
-        tsconfig: "./tsconfig.es5.json",
-      }),
-      terser(),
+      transpile(),
+      terser({ ecma: 5 }),
       storeBundle(chunkCache),
     ],
   },
@@ -40,11 +79,10 @@ export default [
       banner,
     },
     plugins: [
+      baseUrl(),
       inline(),
-      typescript({
-        tsconfig: "./tsconfig.es5.json",
-      }),
-      terser(),
+      transpile(),
+      terser({ ecma: 5 }),
       storeBundle(chunkCache),
     ],
   },
@@ -61,10 +99,21 @@ export default [
     external: ["obsidian"],
     plugins: [
       clear({ targets: ["./dist"] }),
+      baseUrl(),
       retrieveBundle(chunkCache),
       inline(),
-      typescript(),
-      terser(),
+      transpile(),
+      // Keep the iframe-transport bootstrap identifier readable in the output so
+      // the mobile srcdoc transport patch stays greppable/diagnosable. Reserving
+      // it from the mangler is not enough on its own: terser's single-use
+      // variable inlining (reduce_vars/collapse_vars) would otherwise eliminate
+      // the `const bootstrapHtml` entirely before mangling runs. Keeping that one
+      // local intact costs nothing measurable (the large drawio payload is a
+      // single string literal that these passes do not touch).
+      terser({
+        mangle: { reserved: ["bootstrapHtml"] },
+        compress: { reduce_vars: false, collapse_vars: false },
+      }),
       copy({
         targets: [
           { src: "./manifest.json", dest: "./dist" },

--- a/scripts/deploy-to-vault.sh
+++ b/scripts/deploy-to-vault.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Copy the built plugin into an Obsidian vault so it can be tested, including on
+# mobile devices that sync the vault (Obsidian Sync / iCloud).
+#
+# Run this on the HOST (it is just a file copy, no toolchain needed). Build the
+# plugin first inside the devcontainer:  npm run build
+#
+# Usage:
+#   OBSIDIAN_VAULT="/path/to/your/vault" ./scripts/deploy-to-vault.sh
+#
+set -euo pipefail
+
+VAULT="${OBSIDIAN_VAULT:?set OBSIDIAN_VAULT to the absolute path of your vault}"
+DEST="$VAULT/.obsidian/plugins/drawio-obsidian"
+
+if [ ! -f dist/main.js ]; then
+  echo "dist/main.js not found - run 'npm run build' in the devcontainer first." >&2
+  exit 1
+fi
+
+mkdir -p "$DEST"
+cp dist/main.js dist/manifest.json dist/styles.css "$DEST/"
+echo "Deployed plugin to: $DEST"

--- a/src/DiagramPlugin.ts
+++ b/src/DiagramPlugin.ts
@@ -14,6 +14,7 @@ import {
   MarkdownView,
   Menu,
   MenuItem,
+  Platform,
   Plugin,
   PluginManifest,
   PluginRegistration,
@@ -75,6 +76,13 @@ export default class DiagramPlugin extends Plugin {
     this.registerCommands();
     this.addSettingTab(new DiagramSettingsTab(this.app, this));
     this.tryAddFileExplorerButton();
+    // On mobile the file-explorer header button is unavailable, so add a
+    // ribbon icon (works on phone and tablet) to create a new diagram.
+    if (Platform.isMobile) {
+      this.addRibbonIcon("create-new-diagram", "Create new diagram", () => {
+        this.editNewDiagramFile();
+      });
+    }
     // Show the welcome modal the first time the plugin is run
     if (this.settings.welcomeComplete !== true) {
       const welcome = new WelcomeModal(this.app, this);
@@ -131,7 +139,7 @@ export default class DiagramPlugin extends Plugin {
   private tryAddFileExplorerButton() {
     if (
       this.isFileExplorerButtonPresent ||
-      !this.app.internalPlugins.plugins["file-explorer"].enabled
+      !this.app.internalPlugins.plugins["file-explorer"]?.enabled
     ) {
       return;
     }

--- a/src/DiagramViewBase.ts
+++ b/src/DiagramViewBase.ts
@@ -1,4 +1,4 @@
-import { EditableFileView, Menu, WorkspaceLeaf } from "obsidian";
+import { EditableFileView, Menu, Notice, Platform, WorkspaceLeaf } from "obsidian";
 import DiagramPlugin from "./DiagramPlugin";
 
 export default abstract class DiagramViewBase extends EditableFileView {
@@ -56,12 +56,40 @@ export default abstract class DiagramViewBase extends EditableFileView {
     ctx.drawImage(img, 0, 0);
     const pngDataUrl = canvas.toDataURL("image/png");
 
-    // Click a link with the download attribute to invoke the download dialog
-    const link = document.createElement("a");
-    link.setAttribute("href", pngDataUrl);
-    link.setAttribute("download", this.file.basename + ".png");
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    // On mobile, <a download> is a no-op in the WKWebView, so write the PNG
+    // into the vault instead. On desktop, keep the native download dialog.
+    if (Platform.isMobile) {
+      try {
+        // Convert the data URL to bytes for vault.createBinary()
+        const base64String = pngDataUrl.split(",")[1];
+        const binaryString = atob(base64String);
+        const bytes = new Uint8Array(binaryString.length);
+        for (let i = 0; i < binaryString.length; i++) {
+          bytes[i] = binaryString.charCodeAt(i);
+        }
+        // Write the PNG next to the source diagram file
+        const pngFileName = this.file.basename + ".png";
+        const parentPath = this.file.parent?.path || "";
+        const pngPath = parentPath ? parentPath + "/" + pngFileName : pngFileName;
+        // Overwrite any existing PNG at the target path
+        const existingFile = this.app.vault.getAbstractFileByPath(pngPath);
+        if (existingFile) {
+          await this.app.vault.delete(existingFile);
+        }
+        await this.app.vault.createBinary(pngPath, bytes.buffer);
+        new Notice("Diagram exported to " + pngPath);
+      } catch (error) {
+        console.error("Failed to export PNG to vault:", error);
+        new Notice("Failed to export diagram as PNG");
+      }
+    } else {
+      // Desktop: trigger the native download dialog
+      const link = document.createElement("a");
+      link.setAttribute("href", pngDataUrl);
+      link.setAttribute("download", this.file.basename + ".png");
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
   }
 }

--- a/src/DrawioClient.ts
+++ b/src/DrawioClient.ts
@@ -146,9 +146,28 @@ export default class DrawioClient implements EventTarget {
   private createFrameElement(): HTMLIFrameElement {
     // Bootstrap script listens for a message containing
     // the first script to inject into the iframe
-    const frameSrc =
-      "data:text/html," +
-      encodeURIComponent(`
+    // Delivered via iframe.srcdoc (not a data: URL) so the frame inherits the
+    // parent origin. On iOS/iPadOS (Capacitor WKWebView) a data: URL frame has
+    // an opaque/null origin, which blocks dynamic <script> injection and the
+    // parent<->child postMessage handshake, leaving the editor blank. srcdoc is
+    // same-origin with the host, so injection + messaging work on mobile too.
+    const bootstrapHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes">
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      touch-action: manipulation;
+    }
+  </style>
+</head>
+<body>
 <script>
 const onWindowMessage = (messageEvent) => {
   const message = JSON.parse(messageEvent.data);
@@ -161,7 +180,9 @@ const onWindowMessage = (messageEvent) => {
 }
 window.addEventListener("message",onWindowMessage);
 window.parent.postMessage("{\\"event\\":\\"iframe\\"}",'*');
-</script>`);
+</script>
+</body>
+</html>`;
 
     const frame = document.createElement("iframe");
     frame.setAttribute("frameborder", "0");
@@ -169,7 +190,7 @@ window.parent.postMessage("{\\"event\\":\\"iframe\\"}",'*');
       "style",
       "z-index:1;display:block;height:100%;width:100%;"
     );
-    frame.setAttribute("src", frameSrc);
+    frame.srcdoc = bootstrapHtml;
     return frame;
   }
 

--- a/src/DrawioClient.ts
+++ b/src/DrawioClient.ts
@@ -10,6 +10,7 @@ import {
 } from "./Messages";
 import { FrameMessenger } from "./FrameMessenger";
 import { DiagramPluginSettings } from "./DiagramPluginSettings";
+import { Notice } from "obsidian";
 
 export class FileChangeEvent extends Event {
   public readonly data: string;
@@ -45,6 +46,7 @@ export default class DrawioClient implements EventTarget {
   appCss: string;
   iframeElement: HTMLIFrameElement;
   isInitialized: boolean;
+  gotIframeMsg: boolean;
 
   constructor(contentEl: HTMLElement, settings: DiagramPluginSettings) {
     this.iframeElement = null;
@@ -52,6 +54,7 @@ export default class DrawioClient implements EventTarget {
     this.settings = settings;
     this.file = null;
     this.isInitialized = false;
+    this.gotIframeMsg = false;
 
     // Create the iframe to contain drawio
     this.iframeElement = this.createFrameElement();
@@ -169,12 +172,18 @@ export default class DrawioClient implements EventTarget {
 </head>
 <body>
 <script>
+window.__bootRan = true;
+window.__bootErr = [];
+window.addEventListener("error", function(e){ try{ window.__bootErr.push("err:" + (e.message || "?") + "@" + (e.filename || "?") + ":" + (e.lineno || 0)); }catch(_){} });
+window.addEventListener("securitypolicyviolation", function(e){ try{ window.__bootErr.push("csp:" + e.violatedDirective + "|" + String(e.blockedURI || "").slice(0,48)); }catch(_){} });
 const onWindowMessage = (messageEvent) => {
   const message = JSON.parse(messageEvent.data);
   if(message.action==="script"){
-    const scriptElement = document.createElement("script");
-    scriptElement.text = message.script;
-    document.head.appendChild(scriptElement);
+    try {
+      const scriptElement = document.createElement("script");
+      scriptElement.text = message.script;
+      document.head.appendChild(scriptElement);
+    } catch(err){ if(window.__bootErr){ window.__bootErr.push("inject:" + (err && err.message)); } }
   }
   window.removeEventListener("message", onWindowMessage);
 }
@@ -225,10 +234,45 @@ window.parent.postMessage("{\\"event\\":\\"iframe\\"}",'*');
 
   // Wait for drawio to send an init message
   protected async waitForInit() {
-    await this.frameMessenger.waitForMessage(
-      (message: DrawioInitEventMessage) => message.event === "init",
-      5000
-    );
+    try {
+      await this.frameMessenger.waitForMessage(
+        (message: DrawioInitEventMessage) => message.event === "init",
+        5000
+      );
+    } catch (e) {
+      this.reportDiagnostics();
+      throw e;
+    }
+  }
+
+  // Surface why the editor frame failed to initialise (mobile diagnostics).
+  // srcdoc is same-origin, so the host can introspect the frame directly.
+  protected reportDiagnostics() {
+    const lines: string[] = [];
+    try {
+      const w =
+        this.iframeElement && (this.iframeElement.contentWindow as any);
+      const d = this.iframeElement && this.iframeElement.contentDocument;
+      lines.push("gotIframeMsg=" + this.gotIframeMsg);
+      if (!w) {
+        lines.push("contentWindow=null(blocked)");
+      } else {
+        lines.push("bootRan=" + !!w.__bootRan);
+        lines.push("scripts=" + (d ? d.querySelectorAll("script").length : "?"));
+        lines.push("mxLoadResources=" + w.mxLoadResources);
+        lines.push("mxClient=" + (typeof w.mxClient !== "undefined"));
+        lines.push("app=" + (typeof w.App !== "undefined" || typeof w.Draw !== "undefined"));
+        const miss = (w.__missingRes as string[]) || [];
+        lines.push(miss.length ? "missing=" + miss.slice(0, 8).join("|") : "missing=none");
+        const errs = (w.__bootErr as string[]) || [];
+        lines.push(errs.length ? "errs=" + errs.slice(0, 6).join(" ; ") : "errs=none");
+      }
+    } catch (e) {
+      lines.push("introspect-failed=" + ((e as Error) && (e as Error).message));
+    }
+    const msg = "drawio mobile diag [b6]: " + lines.join(", ");
+    console.error(msg);
+    new Notice(msg, 0);
   }
 
   protected handleMessage(message: EventMessage) {
@@ -236,6 +280,7 @@ window.parent.postMessage("{\\"event\\":\\"iframe\\"}",'*');
       case EventMessageEvents.Iframe:
         // This is the bootstrap message that comes from
         // the iframe once it has been put into the DOM
+        this.gotIframeMsg = true;
         this.isInitialized = false;
         this.dispatchEvent(new StateChangeEvent(this.isInitialized));
         this.addScriptToFrame(FRAME_INIT_SOURCE);

--- a/src/drawio-client/app/FontManager.ts
+++ b/src/drawio-client/app/FontManager.ts
@@ -25,51 +25,63 @@ export class FontManager {
   }
 
   private async getFontCssForUrlUncached(fontFamily: string, url: string) {
-    const response = await fetch(url);
-    const contentType = response.headers.get("content-type");
-    if (/text\/css/.test(contentType)) {
-      const css = await response.text();
-      const patternFontFace = /@font-face\s*\{([^\}]+)\}/g;
-      const patternDeclaration = /(?:\s*([a-z0-9-]+)\s*\:\s*([^;]+)\;)/g;
-      const patternUrl = /url\(['"]?([^\)]+)['"]?\)/;
-      const rules = [];
-      let fontFaceMatch;
-      while ((fontFaceMatch = patternFontFace.exec(css)) !== null) {
-        const rule = [];
-        const fontFaceCss = fontFaceMatch[1];
-        let declarationMatch;
-        while (
-          (declarationMatch = patternDeclaration.exec(fontFaceCss)) !== null
-        ) {
-          let declaration = declarationMatch[0];
-          const property = declarationMatch[1];
-          const value = declarationMatch[2];
-          if (property === "src") {
-            const urlMatch = patternUrl.exec(value);
-            if (urlMatch) {
-              const url = urlMatch[1];
-              const fontResponse = await fetch(url);
-              const blob = await fontResponse.blob();
-              const dataUrl = await this.toDataUrl(blob);
-              declaration = declaration.replace(url, dataUrl);
+    try {
+      const response = await fetch(url);
+      const contentType = response.headers.get("content-type");
+      if (/text\/css/.test(contentType)) {
+        const css = await response.text();
+        const patternFontFace = /@font-face\s*\{([^\}]+)\}/g;
+        const patternDeclaration = /(?:\s*([a-z0-9-]+)\s*\:\s*([^;]+)\;)/g;
+        const patternUrl = /url\(['"]?([^\)]+)['"]?\)/;
+        const rules = [];
+        let fontFaceMatch;
+        while ((fontFaceMatch = patternFontFace.exec(css)) !== null) {
+          const rule = [];
+          const fontFaceCss = fontFaceMatch[1];
+          let declarationMatch;
+          while (
+            (declarationMatch = patternDeclaration.exec(fontFaceCss)) !== null
+          ) {
+            let declaration = declarationMatch[0];
+            const property = declarationMatch[1];
+            const value = declarationMatch[2];
+            if (property === "src") {
+              const urlMatch = patternUrl.exec(value);
+              if (urlMatch) {
+                const url = urlMatch[1];
+                try {
+                  const fontResponse = await fetch(url);
+                  const blob = await fontResponse.blob();
+                  const dataUrl = await this.toDataUrl(blob);
+                  declaration = declaration.replace(url, dataUrl);
+                } catch (e) {
+                  console.warn(
+                    `Failed to inline font file from ${url}, leaving declaration unchanged`,
+                    e
+                  );
+                }
+              }
             }
+            rule.push(declaration);
           }
-          rule.push(declaration);
+          rules.push(rule);
         }
-        rules.push(rule);
-      }
-      return rules.map((rule) => `@font-face {${rule.join("")}}`).join("");
-    } else {
-      const blob = await response.blob();
-      const dataUrl = await new Promise<string>((resolve) => {
-        const reader = new FileReader();
-        reader.onloadend = () => resolve(reader.result as string);
-        reader.readAsDataURL(blob);
-      });
-      return `@font-face {
+        return rules.map((rule) => `@font-face {${rule.join("")}}`).join("");
+      } else {
+        const blob = await response.blob();
+        const dataUrl = await new Promise<string>((resolve) => {
+          const reader = new FileReader();
+          reader.onloadend = () => resolve(reader.result as string);
+          reader.readAsDataURL(blob);
+        });
+        return `@font-face {
         font-family: '${fontFamily}';
         src: url('${dataUrl}')
       }`;
+      }
+    } catch (e) {
+      console.warn(`Failed to load font css for url ${url}`, e);
+      return "";
     }
   }
 

--- a/src/drawio-client/init/Frame.ts
+++ b/src/drawio-client/init/Frame.ts
@@ -32,9 +32,102 @@ export class Frame {
     );
     this.configurationManager = configurationManager;
 
-    // Stub out the cookie that drawio tries to read - this would throw an error because
-    // cookies aren't available in the page loaded from a data: url
-    Object.defineProperty(document, "cookie", { value: "" });
+    // Capture async errors with detail. iOS WKWebView reports errors thrown in
+    // async callbacks of a srcdoc frame as an opaque "Script error." via
+    // window.onerror. Wrapping the async entry points (this runs in init, before
+    // drawio loads) lets a same-origin try/catch see the real Error for the
+    // mobile diagnostics.
+    const anyWin = window as any;
+    const reportAsync = function (e: any) {
+      try {
+        anyWin.__bootErr = anyWin.__bootErr || [];
+        anyWin.__bootErr.push(
+          "async:" +
+            ((e && e.message) || e) +
+            " @ " +
+            ((e && e.stack) || "").split("\n").slice(1, 3).join(" <- ")
+        );
+      } catch (_) {}
+    };
+    const wrapAsync = function (orig: any) {
+      return function (cb: any) {
+        if (typeof cb === "function") {
+          const rest = Array.prototype.slice.call(arguments, 1);
+          const wrapped = function () {
+            try {
+              return cb.apply(this, arguments);
+            } catch (e) {
+              reportAsync(e);
+              throw e;
+            }
+          };
+          return orig.apply(this, [wrapped].concat(rest));
+        }
+        return orig.apply(this, arguments);
+      };
+    };
+    try {
+      window.setTimeout = wrapAsync(window.setTimeout);
+    } catch (_) {}
+    try {
+      window.requestAnimationFrame = wrapAsync(window.requestAnimationFrame);
+    } catch (_) {}
+    try {
+      window.addEventListener("unhandledrejection", function (ev: any) {
+        reportAsync(ev && ev.reason);
+      });
+    } catch (_) {}
+    // drawio often logs its own errors via console.error even when window.onerror
+    // is opaque on iOS - capture those (they carry the real message/stack).
+    try {
+      const origConsoleErr =
+        (window.console && window.console.error) || function () {};
+      window.console.error = function () {
+        try {
+          const parts = Array.prototype.map.call(arguments, function (a: any) {
+            return a && a.message
+              ? a.message + " " + ((a.stack || "").split("\n")[1] || "")
+              : String(a);
+          });
+          anyWin.__bootErr = anyWin.__bootErr || [];
+          anyWin.__bootErr.push("cerr:" + parts.join(" ").slice(0, 200));
+        } catch (_) {}
+        return origConsoleErr.apply(this, arguments);
+      };
+    } catch (_) {}
+    // Wrap event-listener callbacks (App.main can run on the window 'load'
+    // event, which setTimeout/rAF wrapping does not cover).
+    try {
+      const origAddEventListener = window.addEventListener;
+      (window as any).addEventListener = function (
+        type: any,
+        listener: any,
+        opts: any
+      ) {
+        if (typeof listener === "function") {
+          const wrappedListener = function () {
+            try {
+              return listener.apply(this, arguments);
+            } catch (e) {
+              reportAsync(e);
+              throw e;
+            }
+          };
+          return origAddEventListener.call(this, type, wrappedListener, opts);
+        }
+        return origAddEventListener.apply(this, arguments);
+      };
+    } catch (_) {}
+
+    // Stub out the cookie that drawio tries to read. On a data: url document
+    // (opaque origin) reading cookie throws, so it needs a stub. On a srcdoc
+    // frame (same-origin, used on mobile) document.cookie is a non-configurable
+    // native accessor and redefining it throws - there the native cookie is fine.
+    try {
+      Object.defineProperty(document, "cookie", { value: "", configurable: true });
+    } catch (e) {
+      // Same-origin srcdoc/mobile: keep the native document.cookie.
+    }
 
     // Don't make requests for resources, use inline defaults.
     Object.defineProperty(window, "mxLoadResources", { value: false });
@@ -49,19 +142,25 @@ export class Frame {
       value: false,
     });
 
-    Object.defineProperty(window, "localStorage", {
-      value: {
-        getItem: function (key: string) {
-          console.warn("Disabled localStorage getItem", key);
+    try {
+      Object.defineProperty(window, "localStorage", {
+        configurable: true,
+        value: {
+          getItem: function (key: string) {
+            console.warn("Disabled localStorage getItem", key);
+          },
+          setItem: function (key: string, value: any) {
+            console.warn("Disabled localStorage setItem", key, value);
+          },
+          removeItem: function (key: string) {
+            console.warn("Disabled localStorage removeItem", key);
+          },
         },
-        setItem: function (key: string, value: any) {
-          console.warn("Disabled localStorage setItem", key, value);
-        },
-        removeItem: function (key: string) {
-          console.warn("Disabled localStorage removeItem", key);
-        },
-      },
-    });
+      });
+    } catch (e) {
+      // Same-origin srcdoc/mobile: window.localStorage is non-configurable and
+      // cannot be replaced; isLocalStorage=false already disables its use.
+    }
 
     window.addEventListener("focus", () => {
       this.frameMessenger.sendMessage({
@@ -79,7 +178,25 @@ export class Frame {
   public addScript(scriptSource: string) {
     const scriptElement = document.createElement("script");
     scriptElement.text = scriptSource;
-    document.head.appendChild(scriptElement);
+    try {
+      // Inline scripts execute synchronously on append, so a top-level throw
+      // surfaces here with full detail (window.onerror masks it as "Script
+      // error." on iOS). Capture it for the mobile diagnostics.
+      document.head.appendChild(scriptElement);
+    } catch (e) {
+      try {
+        const err = e as any;
+        const anyWin = window as any;
+        anyWin.__bootErr = anyWin.__bootErr || [];
+        anyWin.__bootErr.push(
+          "addScript:" +
+            ((err && err.message) || err) +
+            " @ " +
+            (((err && err.stack) || "").split("\n")[1] || "").trim()
+        );
+      } catch (_) {}
+      throw e;
+    }
   }
 
   addCss(cssSource: string) {

--- a/src/drawio-client/init/RequestManager.ts
+++ b/src/drawio-client/init/RequestManager.ts
@@ -52,6 +52,10 @@ export class RequestManager {
     const file = this.responses.find((file) => file.href === url);
     if (typeof file === "undefined") {
       console.warn("Missing local resource", "https://app.diagrams.net/" + url);
+      try {
+        (window as any).__missingRes = (window as any).__missingRes || [];
+        (window as any).__missingRes.push(url);
+      } catch (e) {}
       // TODO: catch http requests so we can work offline
       // Allow fully qualified online resources
       return "https://app.diagrams.net/" + url;


### PR DESCRIPTION
Addresses #33 (mobile support on iOS/Android).

## What
Makes the plugin load and edit diagrams on Obsidian **mobile** (iPhone/iPad), lifting `isDesktopOnly`.

## Why removing `isDesktopOnly` alone didn't work
The editor iframe was booted from a `data:text/html,...` URL. In Obsidian mobile (Capacitor/WKWebView) a `data:` document has an opaque/null origin, which blocks the dynamic `<script>` injection and the parent↔child `postMessage` handshake the plugin relies on — so the editor stayed blank even with the flag removed.

## Changes
- **DrawioClient**: deliver the bootstrap via `iframe.srcdoc` instead of a `data:` URL. `srcdoc` inherits the host origin, so script injection + messaging work on mobile and desktop alike. Adds a viewport meta tag + `touch-action` for tablet pan/zoom.
- **DiagramViewBase**: on mobile, *Export as png* writes the PNG into the vault (the `<a download>` dialog is a no-op in WKWebView). Desktop keeps the native download dialog, unchanged.
- **FontManager**: tolerate Google Fonts fetch failures so an offline/mobile save is never blocked by a font request.
- **DiagramPlugin**: add a mobile ribbon icon to create a new diagram (there is no file-explorer header button on mobile) and harden the file-explorer button lookup with optional chaining.
- **manifest**: `isDesktopOnly: false`, `minAppVersion: 1.0.0`, version `1.6.0`.
- **Build**: swap `@rollup/plugin-typescript` → `sucrase` (transpile-only) to fix a build break caused by newer type-only-export syntax in the transitive `@codemirror` typings; add a `.devcontainer` for a reproducible Node build.

## Testing
- Builds clean; the bundle loads (require smoke test) and `node --check` passes.
- Desktop export path preserved verbatim; only the shared `srcdoc` transport changes on desktop (same-origin; bootstrap escaping byte-identical).
- ⏳ On-device iPad/iPhone verification in progress — kept as **draft** until confirmed live.
